### PR TITLE
fix(ci): also push major floating tag and pre release

### DIFF
--- a/build/registry/tag_test.go
+++ b/build/registry/tag_test.go
@@ -65,9 +65,12 @@ func Test_ociTagsToUpdate(t *testing.T) {
 		existingTags []string
 		want         []string
 	}{
-		{"latest", "0.3.2", []string{"0.1.1", "0.2.0", "0.3.1"}, []string{"0.3.2", "0.3", "latest"}},
+		{"latest", "0.3.2", []string{"0.1.1", "0.2.0", "0.3.1"}, []string{"0", "0.3.2", "0.3", "latest"}},
+		{"latest_1", "1.0.0", []string{"0.1.1", "0.2.0", "0.3.1"}, []string{"1", "1.0.0", "1.0", "latest"}},
 		{"older", "0.1.1", []string{"0.1.2", "0.2.0", "0.3.1"}, []string{"0.1.1"}},
 		{"latest_in_line", "0.1.3", []string{"0.1.2", "0.2.0", "0.3.1"}, []string{"0.1.3", "0.1"}},
+		{"version_1", "1.0.2", []string{"0.1.2", "0.2.0", "1.0.0", "2.0.0", "2.0.2"}, []string{"1", "1.0", "1.0.2"}},
+		{"prerelease", "0.1.4-rc1", []string{"0.1.2", "0.1.3"}, []string{"0.1.4-rc1"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Luca Guerra <luca@guerra.sh>

This adds, e.g. the tag `0` when we push something like `0.1`, also ensures that pre releases are also pushed, even if not latest.