### PR TITLE
fix(registry/config): set correct key for engine version in config layer

### DIFF
--- a/build/registry/requirements.go
+++ b/build/registry/requirements.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	rulesEngineAnchor = "- required_engine_version"
-	engineVersionKey  = "required_engine_version"
+	engineVersionKey  = "engine_version"
 )
 
 // ErrReqNotFound error when the requirements are not found in the rulesfile.


### PR DESCRIPTION
Signed-off-by: Aldo Lacuku <aldo@lacuku.eu>

Use the `engine_version` instead of `required_engine_version` as a key when setting the engine version requirement in the config layer of the OCI artifacts.