### PR TITLE
rule(write_etc_common): Ignore writes by etckeeper under /etc/.git/

### DIFF
--- a/rules/falco-sandbox_rules.yaml
+++ b/rules/falco-sandbox_rules.yaml
@@ -834,6 +834,17 @@
        fd.name startswith /etc/ssh/ssh_monitor_config_ or
        fd.name startswith /etc/ssh/ssh_config_))
 
+- macro: etckeeper_activities
+  condition: (never_true)
+
+- macro: etckeeper
+  condition: >
+    (proc.aname = etckeeper
+     or (proc.aname in (50vcs-commit, 30store-metadata, 50uncommitted-c))
+    and (fd.name startswith /etc/.git/
+         or fd.name = /etc/.etckeeper)
+    and etckeeper_activities)
+
 - macro: multipath_writing_conf
   condition: (proc.name = multipath and fd.name startswith /etc/multipath/)
 
@@ -961,6 +972,7 @@
     and not automount_using_mtab
     and not mcafee_writing_cma_d
     and not avinetworks_supervisor_writing_ssh
+    and not etckeeper
     and not multipath_writing_conf
     and not calico_node)
 


### PR DESCRIPTION
Every time etckeeper update the git history of the content in /etc/, it update files in /etc/.git/.  This trigger a warning from falco about writes in /etc/ for every time the cron job or package update.  This change tell the write_etc_common macro to ignore all writes under /etc/.git/ by a process whos great grandparent is etckeeper.  The parent is 'git' and the grandparent is 50vcs-commit.

/kind bug
/kind design
/kind feature
/area rules

Signed-off-by: Petter Reinholdtsen <pere@hungry.com>

Setting WIP to get feedback on the approach, in case there is a better way to do this.  I want to create a similar pull request for cups and /etc/cups/printers.conf, and want feedback on the best alternative.