### PR TITLE
Added dnf-automatic to list of rpm_binaries

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -218,7 +218,7 @@
 # The explicit quotes are needed to avoid the - characters being
 # interpreted by the filter expression.
 - list: rpm_binaries
-  items: [dnf, rpm, rpmkey, yum, '"75-system-updat"', rhsmcertd-worke, rhsmcertd, subscription-ma,
+  items: [dnf, dnf-automatic, rpm, rpmkey, yum, '"75-system-updat"', rhsmcertd-worke, rhsmcertd, subscription-ma,
           repoquery, rpmkeys, rpmq, yum-cron, yum-config-mana, yum-debug-dump,
           abrt-action-sav, rpmdb_stat, microdnf, rhn_check, yumdb]
 


### PR DESCRIPTION
The process is called by systemd regularly and write to /var/lib/rpm/rpmdb.sqlite-shm.  This will quiet down the event log on RHEL 9 and possibly other RHEL versions.

/kind bug
/area rules

Signed-off-by: Petter Reinholdtsen <pere@hungry.com>
