### PR TITLE
merge the two docker_binaries into a single one, the first was overrided

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -181,9 +181,6 @@
 - list: sysdigcloud_binaries
   items: [setup-backend, dragent, sdchecks]
 
-- list: docker_binaries
-  items: [docker, dockerd, exe, docker-compose, docker-entrypoi, docker-runc-cur, docker-current, dockerd-current]
-
 - list: k8s_binaries
   items: [hyperkube, skydns, kube2sky, exechealthz, weave-net, loopback, bridge, openshift-sdn, openshift]
 
@@ -3258,7 +3255,7 @@
   tags: [host, container, process, mitre_initial_access, T1190]
 
 - list: docker_binaries
-  items: [dockerd, containerd-shim, "runc:[1:CHILD]", pause]
+  items: [docker, dockerd, containerd-shim, "runc:[1:CHILD]", pause, exe, docker-compose, docker-entrypoi, docker-runc-cur, docker-current, dockerd-current]
 
 - macro: docker_procs
   condition: proc.name in (docker_binaries)


### PR DESCRIPTION
Signed-off-by: Thomas Labarussias <issif+github@gadz.org>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area rules

> /area registry

> /area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

The `falco_rules.yaml` contained 2 lists for `docker_binaries`, without an append, the first was totally override. I merged them into a single one.

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
