### PR TITLE
update(falco_rules): disable three rules by default

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -3120,6 +3120,7 @@
      (fd.sip.name in (c2_server_fqdn_list)))
   output: Outbound connection to C2 server (c2_domain=%fd.sip.name c2_addr=%fd.sip command=%proc.cmdline connection=%fd.name user=%user.name user_loginuid=%user.loginuid container_id=%container.id image=%container.image.repository)
   priority: WARNING
+  enabled: false
   tags: [host, container, network, mitre_command_and_control, TA0011]
 
 - list: white_listed_modules

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -3269,6 +3269,7 @@
         java_network_read and evt.buffer bcontains cafebabe
   output: Java process class file download (user=%user.name user_loginname=%user.loginname user_loginuid=%user.loginuid event=%evt.type connection=%fd.name server_ip=%fd.sip server_port=%fd.sport proto=%fd.l4proto process=%proc.name command=%proc.cmdline pid=%proc.pid parent=%proc.pname buffer=%evt.buffer container_id=%container.id image=%container.image.repository)
   priority: CRITICAL
+  enabled: false
   tags: [host, container, process, mitre_initial_access, T1190]
 
 - list: docker_binaries

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -2392,6 +2392,7 @@
   condition: outbound and fd.sip="169.254.169.254" and container and not ec2_metadata_containers
   output: Outbound connection to EC2 instance metadata service (command=%proc.cmdline pid=%proc.pid connection=%fd.name %container.info image=%container.image.repository:%container.image.tag)
   priority: NOTICE
+  enabled: false
   tags: [network, aws, container, mitre_discovery, T1565]
 
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area rules

**What this PR does / why we need it**:

This sets three rules as disabled by default, each for a different reason:
- `Contact EC2 Instance Metadata Service From Container`: without custom overrides, the rule contains the unrolled condition `container and not container`, which means that the rule never triggers at default and just wastes evaluation time.
- `Outbound Connection to C2 Servers`: without custom overrides, the condition will require one of `fd.sip` and `fd.sip.name` to be contained in empty lists, which is impossible, meaning that the rule never triggers at default and just wastes evaluation time.
- `Java Process Class File Download`: This matches the `recvfrom` syscall, which is IO-related and performance-heavy. The recent Falco developments will automatically exclude those syscalls if the `-A` option is not used, which means that this rule will never trigger by default in the next Falco release.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
