### PR TITLE
Adding conda as a package manager for Python that could be used

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -238,11 +238,13 @@
     frontend, preinst, add-apt-reposit, apt-auto-remova, apt-key,
     apt-listchanges, unattended-upgr, apt-add-reposit, apt-cache, apt.systemd.dai
     ]
+- list: python_package_managers
+  items: [pip, pip3, conda]
 
 # The truncated dpkg-preconfigu is intentional, process names are
 # truncated at the falcosecurity-libs level.
 - list: package_mgmt_binaries
-  items: [rpm_binaries, deb_binaries, update-alternat, gem, npm, pip, pip3, sane-utils.post, alternatives, chef-client, apk, snapd]
+  items: [rpm_binaries, deb_binaries, update-alternat, gem, npm, python_package_managers, sane-utils.post, alternatives, chef-client, apk, snapd]
 
 - macro: package_mgmt_procs
   condition: proc.name in (package_mgmt_binaries)


### PR DESCRIPTION
Thanks to @edirgarcia for the idea : D

**What type of PR is this?**

/kind feature

The list of package managers does not include Conda, a common manager for Python packages and lower-level depenencies.


**Any specific area of the project related to this PR?**

/area rules

**What this PR does / why we need it**:

Without this change, some package manager use cases may be missed,

**Which issue(s) this PR fixes**:

No issue included at the moment

**Special notes for your reviewer**:
