### PR TITLE
Rule: Search Private Keys or Passwords / Add private key candidates

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -2623,7 +2623,13 @@
   condition: >
     (spawned_process and
      ((grep_commands and private_key_or_password) or
-      (proc.name = "find" and (proc.args contains "id_rsa" or proc.args contains "id_dsa")))
+      (proc.name = "find" and
+        (proc.args contains "id_rsa" or 
+         proc.args contains "id_dsa" or 
+         proc.args contains "id_ed25519" or 
+         proc.args contains "id_ecdsa"
+        )
+      ))
     )
   output: >
     Grep private keys or passwords activities found


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> /kind feature

**Any specific area of the project related to this PR?**
> /area rules

**What this PR does / why we need it**:

Private key candidates will be searched by attacker are insufficient. At least, Ubuntu 22.04 may create the following key by default.
- `id_ed25519`
- `id_ecdsa`