### PR TITLE
 fix(registry/index): do not add artifact name to keywords if already present

### DIFF
--- a/build/registry/index.go
+++ b/build/registry/index.go
@@ -36,7 +36,7 @@ func pluginRulesToIndexEntry(rf Rulesfile, registry, repo string) *index.Entry {
 		Repository:  repo,
 		Description: rf.Description,
 		Home:        rf.URL,
-		Keywords:    append(rf.Keywords, rf.Name),
+		Keywords:    appendIfNotPresent(rf.Keywords, rf.Name),
 		License:     rf.License,
 		Maintainers: rf.Maintainers,
 		Sources:     []string{rf.URL},
@@ -68,4 +68,17 @@ func upsertIndexFile(r *Registry, ociArtifacts map[string]string, indexPath stri
 	upsertIndex(r, ociArtifacts, i)
 
 	return i.Write(indexPath)
+}
+
+// Add new item to a slice if not present.
+func appendIfNotPresent(keywords []string, kw string) []string {
+	// If the keyword already exist do nothing.
+	for i := range keywords {
+		if keywords[i] == kw {
+			return keywords
+		}
+	}
+
+	// Add the keyword
+	return append(keywords, kw)
 }

--- a/build/registry/testdata/registry.yaml
+++ b/build/registry/testdata/registry.yaml
@@ -8,6 +8,8 @@ rulesfiles:
         email: cncf-falco-dev@lists.cncf.io
     path: rules/falco_rules.yaml
     license: apache-2.0
+    keywords:
+      - falco
     url: https://github.com/falcosecurity/rules/blob/main/rules/falco_rules.yaml
   - name: applications
     description: Application rules


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area rules

/area registry

> /area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

The artifact name is added to the list of keywords when generating the `index.yaml` file. It could happen that the list of keywords is in ` registry.yaml` already contains the artifact name. This fix checks if the artifact name is contained in the keywords, if not adds it

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
