### PR TITLE
feat(build/registry): return built oci artifact digest

### DIFF
--- a/build/registry/oci.go
+++ b/build/registry/oci.go
@@ -27,19 +27,25 @@ import (
 	ocipusher "github.com/falcosecurity/falcoctl/pkg/oci/pusher"
 )
 
-func pushCompressedRulesfile(ociClient remote.Client, filePath, repoRef, repoGit string, tags []string, config *oci.ArtifactConfig) error {
+// pushCompressedRulesfile publishes rulesfile as OCI artifact and returns its digest.
+// It possibly returns an error.
+func pushCompressedRulesfile(
+	ociClient remote.Client,
+	filePath, repoRef, repoGit string,
+	tags []string,
+	config *oci.ArtifactConfig) (*string, error) {
 	klog.Infof("Processing compressed rulesfile %q for repo %q and tags %s...", filePath, repoRef, tags)
 
 	pusher := ocipusher.NewPusher(ociClient, false, nil)
-	_, err := pusher.Push(context.Background(), oci.Rulesfile, repoRef,
+	artifact, err := pusher.Push(context.Background(), oci.Rulesfile, repoRef,
 		ocipusher.WithTags(tags...),
 		ocipusher.WithFilepaths([]string{filePath}),
 		ocipusher.WithAnnotationSource(repoGit),
 		ocipusher.WithArtifactConfig(*config))
 
 	if err != nil {
-		return fmt.Errorf("an error occurred while pushing: %w", err)
+		return nil, fmt.Errorf("an error occurred while pushing: %w", err)
 	}
 
-	return nil
+	return &artifact.Digest, nil
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area registry
/area build

**What this PR does / why we need it**:

This PR introduces the return of the built OCI artifact's digest.

The digest can later be used to securely reference it. 

**Which issue(s) this PR fixes**:

Fixes #63 

**Special notes for your reviewer**:

This is part of the work for securing the Falco supply chain. In detail of signatures of Falco OCI artifacts, you can read [here](https://github.com/falcosecurity/falcoctl/issues/174#issuecomment-1499338972).

Moreover, this is a very simple implementation. A stage of improvements is open for later.