### PR TITLE
update(rules): add rules for PKT mining pools

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -2856,6 +2856,7 @@
 
 - list: https_miner_domains
   items: [
+    "btm.antpool.com",
     "ca.minexmr.com",
     "cn.stratum.slushpool.com",
     "de.minexmr.com",
@@ -2864,16 +2865,16 @@
     "mine.xmrpool.net",
     "pool.minexmr.com",
     "sg.minexmr.com",
+    "ss.antpool.com",
+    "stratum-btm.antpool.com",
+    "stratum-dash.antpool.com",
     "stratum-eth.antpool.com",
     "stratum-ltc.antpool.com",
+    "stratum-xmc.antpool.com",
     "stratum-zec.antpool.com",
     "stratum.antpool.com",
-    "xmr.crypto-pool.fr",
-    "ss.antpool.com",
-    "stratum-dash.antpool.com",
-    "stratum-xmc.antpool.com",
-    "stratum-btm.antpool.com",
-    "btm.antpool.com"
+    "stratum.zetahash.com",
+    "xmr.crypto-pool.fr"
   ]
 
 - list: http_miner_domains
@@ -2884,6 +2885,9 @@
     "mine.moneropool.com",
     "mine.xmrpool.net",
     "pool.minexmr.com",
+    "pool.pkt.world",
+    "pool.pkteer.com",
+    "pool.pktpool.io",
     "sg.minexmr.com",
     "xmr.crypto-pool.fr"
   ]


### PR DESCRIPTION
/kind feature
/area rules

**What this PR does / why we need it**:

[PacketCrypt](https://docs.pkt.cash/en/latest/mining/) (PKT) is a bandwidth-hard proof-of-work cryptocurrency. This particular coin makes mining viable in environments with limited compute resources but healthy network pipes.

PKT mining requires announcing to a pool, and there are only a few pools available because they need to be the size of a small datacenter to accommodate all of the incoming bandwidth from the protocol.

**Which issue(s) this PR fixes**:

This PR adds all 4 of the [publicly known](https://docs.pkt.cash/en/latest/mining/#choosing-pools-to-mine-in) PKT pools as of 6/2023 to the `miner_domain` rules.

**Special notes for your reviewer**:

I've alphabetized `https_miner_domains` but can revert that if desired.