### PR TITLE
Support azurefile-csi as known_aks_mount_in_privileged_containers

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -3198,8 +3198,8 @@
 
 - macro: known_aks_mount_in_privileged_containers
   condition:
-    (k8s.ns.name = kube-system and container.image.repository = mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi
-    or k8s.ns.name = system and container.image.repository = mcr.microsoft.com/oss/kubernetes-csi/secrets-store/driver)
+    ((k8s.ns.name = kube-system and container.image.repository in (mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi,mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi))
+    or (k8s.ns.name = system and container.image.repository = mcr.microsoft.com/oss/kubernetes-csi/secrets-store/driver))
 
 - macro: user_known_mount_in_privileged_containers
   condition: (never_true)


### PR DESCRIPTION
**Description**
Add mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi to the known_aks_mount_in_privileged_containers macro to suppress unnecessary alerts when using azurefile mounts.  Also added additional parentheses to clarify expected behavior of and/or conditions.

Fixes https://github.com/falcosecurity/rules/issues/69

/kind feature
/area rules