### PR TITLE
update(rules): comment how to reduce reverse shell detection noise

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -3024,6 +3024,19 @@
 - macro: dup
   condition: evt.type in (dup, dup2, dup3)
 
+# As of engine version 20 this rule can be improved by using the fd.types[]
+# field so it only triggers once when all three of std{out,err,in} are
+# redirected.
+#
+# - list: ip_sockets
+#   items: ["ipv4", "ipv6"]
+#
+# - rule: Redirect STDOUT/STDIN to Network Connection in Container once
+#   condition: dup and container and evt.rawres in (0, 1, 2) and fd.type in (ip_sockets) and fd.types[0] in (ip_sockets) and fd.types[1] in (ip_sockets) and fd.types[2] in (ip_sockets) and not user_known_stand_streams_redirect_activities
+#
+# The following rule has not been changed by default as existing users could be
+# relying on the rule triggering when any of std{out,err,in} are redirected.
+
 - rule: Redirect STDOUT/STDIN to Network Connection in Container
   desc: >
     Detect redirecting stdout/stdin to network connection in container (potential reverse shell 


### PR DESCRIPTION
The fd.types field introduced in libs 0.12.0 allows us to improve the reverse shell rule so it fires only once all three of stdout/stderr/stdin are redirected.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. This repo contains a dedicated [contributing guide](https://github.com/falcosecurity/rules/blob/main/CONTRIBUTING.md) that highlights the rules maturity framework definitions as well as the criteria for rules acceptance. Please read it carefully before submitting your PR.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR adds or changes one or more rules, please ensure they conform to https://falco.org/docs/rules/style-guide/ and select the appropriate maturity levels.
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome rule"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind feature

> /kind bug

> /kind cleanup

> /kind design

/kind documentation

> /kind failing-test


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area rules

> /area registry

> /area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Proposed rule [maturity level](https://github.com/falcosecurity/rules/blob/main/CONTRIBUTING.md#maturity-levels)**

> Uncomment one (or more) `/area <>` lines (only for PRs that add or modify rules):

> /area maturity-stable

> /area maturity-incubating

> /area maturity-sandbox

> /area maturity-deprecated

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Informs users of the new `fd.types[]` field and how it can be used to improve the existing reverse shell rule.

**Which issue(s) this PR fixes**: 

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #131 

**Special notes for your reviewer**:

Please see discussion in the above issue for more context to the change.