### PR TITLE
new(rules): Exfiltrating Artifacts via Kubernetes Control Plane

### DIFF
--- a/rules/falco-incubating_rules.yaml
+++ b/rules/falco-incubating_rules.yaml
@@ -1182,3 +1182,42 @@
   output: Environment variables were retrieved from /proc files (file=%fd.name gparent=%proc.aname[2] ggparent=%proc.aname[3] gggparent=%proc.aname[4] evt_type=%evt.type user=%user.name user_uid=%user.uid user_loginuid=%user.loginuid process=%proc.name proc_exepath=%proc.exepath parent=%proc.pname command=%proc.cmdline terminal=%proc.tty exe_flags=%evt.arg.flags %container.info)
   priority: WARNING
   tags: [maturity_incubating, container, filesystem, process, mitre_discovery, T1083]
+
+# The steps libcontainer performs to set up the root program for a container are:
+# - clone + exec self to a program runc:[0:PARENT]
+# - clone a program runc:[1:CHILD] which sets up all the namespaces
+# - clone a second program runc:[2:INIT] + exec to the root program.
+#   The parent of runc:[2:INIT] is runc:0:PARENT]
+# As soon as 1:CHILD is created, 0:PARENT exits, so there's a race
+#   where at the time 2:INIT execs the root program, 0:PARENT might have
+#   already exited, or might still be around. So we handle both.
+# We also let runc:[1:CHILD] count as the parent process, which can occur
+# when we lose events and lose track of state.
+- macro: container_entrypoint
+  condition: (not proc.pname exists or proc.pname in (runc:[0:PARENT], runc:[1:CHILD], runc, docker-runc, exe, docker-runc-cur, containerd-shim, systemd, crio))
+
+- macro: system_level_side_effect_artifacts_kubectl_cp
+  condition: (fd.name startswith /etc or 
+              fd.name startswith /proc or 
+              fd.name startswith /lib or 
+              fd.name startswith /run or 
+              fd.name startswith /usr or 
+              fd.name="/")
+
+- rule: Exfiltrating Artifacts via Kubernetes Control Plane
+  desc: >
+    Detect the copying of artifacts from a container's file system using the Kubernetes control plane (kubectl cp). 
+    This rule can identify potential exfiltration of application secrets from containers' file systems, potentially 
+    revealing the outcomes of unauthorized access and control plane misuse via stolen identities (such as stolen 
+    credentials like Kubernetes serviceaccount tokens). Can be customized by the adopter to only monitor specific 
+    artifact paths, containers, or namespaces as needed.
+  condition: >
+    open_read 
+    and container 
+    and proc.name=tar 
+    and container_entrypoint 
+    and proc.tty=0 
+    and not system_level_side_effect_artifacts_kubectl_cp
+  output: Exfiltrating Artifacts via Kubernetes Control Plane (file=%fd.name evt_type=%evt.type user=%user.name user_uid=%user.uid user_loginuid=%user.loginuid process=%proc.name proc_exepath=%proc.exepath parent=%proc.pname command=%proc.cmdline terminal=%proc.tty exe_flags=%evt.arg.flags %container.info)
+  priority: NOTICE
+  tags: [maturity_incubating, container, filesystem, mitre_exfiltration, TA0010]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. This repo contains a dedicated [contributing guide](https://github.com/falcosecurity/rules/blob/main/CONTRIBUTING.md) that highlights the rules maturity framework definitions as well as the criteria for rules acceptance. Please read it carefully before submitting your PR.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR adds or changes one or more rules, please ensure they conform to https://falco.org/docs/rules/style-guide/ and select the appropriate maturity levels.
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome rule"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind feature

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area rules

> /area registry

> /area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Proposed rule [maturity level](https://github.com/falcosecurity/rules/blob/main/CONTRIBUTING.md#maturity-levels)**

> Uncomment one (or more) `/area <>` lines (only for PRs that add or modify rules):

> /area maturity-stable

/area maturity-incubating

> /area maturity-sandbox

> /area maturity-deprecated

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Many of the existing rules focus on sensitive files in the traditional Linux sense, which might not align well with containerized applications.

Moreover, exfiltrating artifacts from for example Kubernetes goes beyond just the usual ways of malware, interactive access or RCE. It also involves the control plane, which attackers can target if they've gained unauthorized access, such as through stolen credentials. For instance, they might use commands like `kubectl cp`. However, this kind of activity isn't expected to be the norm in production settings. This presents an opportunity to create a broad rule that can catch such behavior without having to individually profile application-specific secrets or artifacts that attackers might try to lift from the container's file system, if applicable.

See https://github.com/falcosecurity/rules/issues/138.

This new rule could not only benefit from feedback, but also expanded testing.

@darryk10 @loresuso @LucaGuerra 

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
