### PR TITLE
fix(build): update latest even if higher prereleases are present

### DIFF
--- a/build/registry/tag.go
+++ b/build/registry/tag.go
@@ -100,22 +100,25 @@ func ociTagsToUpdate(newTag string, existingTags []string) []string {
 		return tagsToUpdate
 	}
 
-	var existingSemvers []semver.Version
+	var existingFinalSemvers []semver.Version
 	for _, tag := range existingTags {
 		if sv, err := semver.Parse(tag); err == nil {
-			existingSemvers = append(existingSemvers, sv)
+			// ignore prereleases
+			if len(sv.Pre) == 0 {
+				existingFinalSemvers = append(existingFinalSemvers, sv)
+			}
 		}
 	}
 
-	if isLatestSemverForMinor(newSemver, existingSemvers) {
+	if isLatestSemverForMinor(newSemver, existingFinalSemvers) {
 		tagsToUpdate = append(tagsToUpdate, fmt.Sprintf("%d.%d", newSemver.Major, newSemver.Minor))
 	}
 
-	if isLatestSemverForMajor(newSemver, existingSemvers) {
+	if isLatestSemverForMajor(newSemver, existingFinalSemvers) {
 		tagsToUpdate = append(tagsToUpdate, fmt.Sprintf("%d", newSemver.Major))
 	}
 
-	if isLatestSemver(newSemver, existingSemvers) {
+	if isLatestSemver(newSemver, existingFinalSemvers) {
 		tagsToUpdate = append(tagsToUpdate, "latest")
 	}
 

--- a/build/registry/tag_test.go
+++ b/build/registry/tag_test.go
@@ -71,6 +71,8 @@ func Test_ociTagsToUpdate(t *testing.T) {
 		{"latest_in_line", "0.1.3", []string{"0.1.2", "0.2.0", "0.3.1"}, []string{"0.1.3", "0.1"}},
 		{"version_1", "1.0.2", []string{"0.1.2", "0.2.0", "1.0.0", "2.0.0", "2.0.2"}, []string{"1", "1.0", "1.0.2"}},
 		{"prerelease", "0.1.4-rc1", []string{"0.1.2", "0.1.3"}, []string{"0.1.4-rc1"}},
+		{"latest_with_prerelease", "1.0.2", []string{"1.0.0", "1.0.1", "2.0.0-rc1"}, []string{"1", "1.0", "1.0.2", "latest"}},
+		{"not_latest_with_prerelease", "1.0.2", []string{"1.0.0", "1.0.1", "2.0.0-rc1", "2.0.0"}, []string{"1", "1.0", "1.0.2"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:


/kind bug



<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build


**What this PR does / why we need it**:

If rules marked as 1.0.0, 1.0.1 and 2.0.0-rc1 are present, when 1.0.2 is released it should still be latest because 2.0.0 is not out yet. Fix the build process to consider this case (note the attached test)

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
