### PR TITLE
update(rules/sandbox): fix misleading name

### DIFF
--- a/rules/falco-sandbox_rules.yaml
+++ b/rules/falco-sandbox_rules.yaml
@@ -1514,7 +1514,7 @@
 - macro: user_known_k8s_client_container_parens
   condition: (user_known_k8s_client_container)
 
-- rule: The docker client is executed in a container
+- rule: Kubernetes Client Tool Launched in Container
   desc: > 
     Detect the execution of a Kubernetes client tool (like docker, kubectl, crictl) within a container, which is typically not expected behavior. 
     Although this rule targets container workloads, monitoring the use of tools like crictl on the host over interactive access could also be 


### PR DESCRIPTION


**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind cleanup

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area rules

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Proposed rule [maturity level](https://github.com/falcosecurity/rules/blob/main/CONTRIBUTING.md#maturity-levels)**

> Uncomment one (or more) `/area <>` lines (only for PRs that add or modify rules):

> /area maturity-stable

> /area maturity-incubating

/area maturity-sandbox

> /area maturity-deprecated

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

As per this discussion: https://github.com/falcosecurity/rules/pull/145#discussion_r1315544548 we can fix the rule name! cc @leogr @incertum 

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
