### PR TITLE
update(rules): add containerd_activities check to Clear Log Activities rule

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -921,6 +921,10 @@
               container.image.repository endswith "openshift3/ose-logging-fluentd" or
               container.image.repository endswith "containernetworking/azure-npm")
 
+- macro: containerd_activities
+  condition: proc.name=containerd and (fd.name startswith "/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/" or
+                                       fd.name startswith "/var/lib/containerd/tmpmounts/")
+
 - rule: Clear Log Activities
   desc: > 
     Detect clearing of critical access log files, typically done to erase evidence that could be attributed to an adversary's 
@@ -928,9 +932,9 @@
     relevant to your environment, and adjust the profiled containers you wish not to be alerted on.
   condition: >
     open_write 
-    and container
     and access_log_files 
     and evt.arg.flags contains "O_TRUNC" 
+    and not containerd_activities
     and not trusted_logging_images 
     and not allowed_clear_log_files
   output: Log files were tampered (file=%fd.name evt_type=%evt.type user=%user.name user_uid=%user.uid user_loginuid=%user.loginuid process=%proc.name proc_exepath=%proc.exepath parent=%proc.pname command=%proc.cmdline terminal=%proc.tty exe_flags=%evt.arg.flags %container.info)

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -922,8 +922,8 @@
               container.image.repository endswith "containernetworking/azure-npm")
 
 - macro: containerd_activities
-  condition: proc.name=containerd and (fd.name startswith "/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/" or
-                                       fd.name startswith "/var/lib/containerd/tmpmounts/")
+  condition: (proc.name=containerd and (fd.name startswith "/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/" or
+                                        fd.name startswith "/var/lib/containerd/tmpmounts/"))
 
 - rule: Clear Log Activities
   desc: > 

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -928,6 +928,7 @@
     relevant to your environment, and adjust the profiled containers you wish not to be alerted on.
   condition: >
     open_write 
+    and container
     and access_log_files 
     and evt.arg.flags contains "O_TRUNC" 
     and not trusted_logging_images 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. This repo contains a dedicated [contributing guide](https://github.com/falcosecurity/rules/blob/main/CONTRIBUTING.md) that highlights the rules maturity framework definitions as well as the criteria for rules acceptance. Please read it carefully before submitting your PR.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR adds or changes one or more rules, please ensure they conform to https://falco.org/docs/rules/style-guide/ and select the appropriate maturity levels.
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome rule"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind feature

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area rules

> /area registry

> /area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Proposed rule [maturity level](https://github.com/falcosecurity/rules/blob/main/CONTRIBUTING.md#maturity-levels)**

> Uncomment one (or more) `/area <>` lines (only for PRs that add or modify rules):

/area maturity-stable

> /area maturity-incubating

> /area maturity-sandbox

> /area maturity-deprecated

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR adds the `containerd_activities` check to the `Clear Log Activities` rule as we have noticed that the rule is being triggered by `containerd` activities in the host, example json output:
```json
{"uuid":"72b27712-9a80-4180-ab2f-c7d298114fb9","output":"18:31:35.698169341: Warning Log files were tampered (file=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/338/fs/var/log/dpkg.log evt_type=openat user=root user_uid=0 user_loginuid=-1 process=containerd proc_exepath=/usr/bin/containerd parent=systemd command=containerd terminal=0 exe_flags=O_TRUNC|O_CREAT|O_WRONLY|O_CLOEXEC|O_F_CREATED container_id=host container_image=<NA> container_image_tag=<NA> container_name=host k8s_ns=<NA> k8s_pod_name=<NA>)","priority":"Warning","rule":"Clear Log Activities","time":"2023-09-27T18:31:35.698169341Z","source":"syscall","output_fields":{"container.id":"host","container.image.repository":null,"container.image.tag":null,"container.name":"host","evt.arg.flags":"O_TRUNC|O_CREAT|O_WRONLY|O_CLOEXEC|O_F_CREATED","evt.time":1695839495698169300,"evt.type":"openat","fd.name":"/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/338/fs/var/log/dpkg.log","k8s.ns.name":null,"k8s.pod.name":null,"proc.cmdline":"containerd","proc.exepath":"/usr/bin/containerd","proc.name":"containerd","proc.pname":"systemd","proc.tty":0,"user.loginuid":-1,"user.name":"root","user.uid":0},"hostname":"production-us-cluster-0-falco-sf9n5","tags":["NIST_800-53_AU-10","T1070","container","filesystem","host","maturity_stable","mitre_defense_evasion"]}
```


**Which issue(s) this PR fixes**: I haven't raised one as it seems quite simple
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
