### PR TITLE
Add detection for attempts to use CVE-2023-4911

### DIFF
--- a/rules/falco-incubating_rules.yaml
+++ b/rules/falco-incubating_rules.yaml
@@ -1253,14 +1253,21 @@
   priority: WARNING
   tags: [maturity_incubating, host, filesystem, mitre_persistence, T1098.004]
 
-# Detection for possible use of CVE-2023-4911
-# Based on https://www.qualys.com/2023/10/03/cve-2023-4911/looney-tunables-local-privilege-escalation-glibc-ld-so.txt
+# possible use of CVE-2023-4911
+- macro: glibc_tunables_env
+  condition: (proc.env icontains GLIBC_TUNABLES)
+
 - rule: Potential Local Privilege Escalation via Environment Variables Misuse
   desc: >
-    Detect use of GLIBC_TUNABLES environment variable, which could be used for priviledge escalation to root on hosts running vulnerable glibc versions.
+    Process run with suspect environment variable that could be attempting privilege escalation. One use case is 
+    detecting the use of the GLIBC_TUNABLES environment variable, which could be used for privilege escalation 
+    on systems running vulnerable glibc versions. Only known and carefully profiled processes that legitimately 
+    exhibit this behavior should be excluded from this rule. This rule is expected to trigger on every attempt, 
+    even failed ones.
   condition: >
-    spawned_process
-    and proc.env icontains GLIBC_TUNABLES
-  output: Process run with GLIBC_TUNABLES environment variable which could be attempting priviledge escalation (env=%proc.env evt_type=%evt.type user=%user.name user_uid=%user.uid user_loginuid=%user.loginuid process=%proc.name proc_exepath=%proc.exepath parent=%proc.pname command=%proc.cmdline terminal=%proc.tty exe_flags=%evt.arg.flags %container.info)
+    spawned_process 
+    and glibc_tunables_env
+  enabled: true
+  output: Process run with suspect environment variable which could be attempting privilege escalation (env=%proc.env evt_type=%evt.type user=%user.name user_uid=%user.uid user_loginuid=%user.loginuid process=%proc.name proc_exepath=%proc.exepath parent=%proc.pname command=%proc.cmdline terminal=%proc.tty exe_flags=%evt.arg.flags %container.info)
   priority: NOTICE
-  tags: [maturity_incubating, host, container, users, mitre_privilege_escalation, TA0111]
+  tags: [maturity_incubating, host, container, users, mitre_privilege_escalation, TA0004]

--- a/rules/falco-incubating_rules.yaml
+++ b/rules/falco-incubating_rules.yaml
@@ -1255,7 +1255,7 @@
 
 # Detection for possible use of CVE-2023-4911
 # Based on https://www.qualys.com/2023/10/03/cve-2023-4911/looney-tunables-local-privilege-escalation-glibc-ld-so.txt
-- rule: Program possibly trying to use CVE-2023-4911
+- rule: Potential Local Privilege Escalation via Environment Variables Misuse
   desc: >
     Detect use of GLIBC_TUNABLES environment variable, which could be used for priviledge escalation to root on hosts running vulnerable glibc versions.
   condition: >
@@ -1263,4 +1263,4 @@
     and proc.env icontains GLIBC_TUNABLES
   output: Process run with GLIBC_TUNABLES environment variable which could be attempting priviledge escalation (env=%proc.env evt_type=%evt.type user=%user.name user_uid=%user.uid user_loginuid=%user.loginuid process=%proc.name proc_exepath=%proc.exepath parent=%proc.pname command=%proc.cmdline terminal=%proc.tty exe_flags=%evt.arg.flags %container.info)
   priority: NOTICE
-  tags: [maturity_incubating, host, users, mitre_privilege_escalation, CVE-2023-4911]
+  tags: [maturity_incubating, host, container, users, mitre_privilege_escalation, TA0111]

--- a/rules/falco-incubating_rules.yaml
+++ b/rules/falco-incubating_rules.yaml
@@ -1252,3 +1252,15 @@
   output: Adding ssh keys to authorized_keys (file=%fd.name evt_type=%evt.type user=%user.name user_uid=%user.uid user_loginuid=%user.loginuid process=%proc.name proc_exepath=%proc.exepath parent=%proc.pname command=%proc.cmdline terminal=%proc.tty exe_flags=%evt.arg.flags)
   priority: WARNING
   tags: [maturity_incubating, host, filesystem, mitre_persistence, T1098.004]
+
+# Detection for possible use of CVE-2023-4911
+# Based on https://www.qualys.com/2023/10/03/cve-2023-4911/looney-tunables-local-privilege-escalation-glibc-ld-so.txt
+- rule: Program possibly trying to use CVE-2023-4911
+  desc: >
+    Detect use of GLIBC_TUNABLES environment variable, which could be used for priviledge escalation to root on hosts running vulnerable glibc versions.
+  condition: >
+    spawned_process
+    and proc.env icontains GLIBC_TUNABLES
+  output: Process run with GLIBC_TUNABLES environment variable which could be attempting priviledge escalation (env=%proc.env evt_type=%evt.type user=%user.name user_uid=%user.uid user_loginuid=%user.loginuid process=%proc.name proc_exepath=%proc.exepath parent=%proc.pname command=%proc.cmdline terminal=%proc.tty exe_flags=%evt.arg.flags %container.info)
+  priority: NOTICE
+  tags: [maturity_incubating, host, users, mitre_privilege_escalation, CVE-2023-4911]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. This repo contains a dedicated [contributing guide](https://github.com/falcosecurity/rules/blob/main/CONTRIBUTING.md) that highlights the rules maturity framework definitions as well as the criteria for rules acceptance. Please read it carefully before submitting your PR.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR adds or changes one or more rules, please ensure they conform to https://falco.org/docs/rules/style-guide/ and select the appropriate maturity levels.
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome rule"
-->

**What type of PR is this?**


/kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area rules


<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Proposed rule [maturity level](https://github.com/falcosecurity/rules/blob/main/CONTRIBUTING.md#maturity-levels)**


/area maturity-incubating


<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
Initial detection of attempts to use CVE-2023-4911
I'm not aware of away to detect GLIBC versions in these rules, so having to rely on this less common environment variable being set