### PR TITLE
Changed required_engine_version from 0.26.0 to 26.

### DIFF
--- a/rules/falco-incubating_rules.yaml
+++ b/rules/falco-incubating_rules.yaml
@@ -25,7 +25,7 @@
 
 # Starting with version 8, the Falco engine supports exceptions.
 # However the Falco rules file does not use them by default.
-- required_engine_version: 0.26.0
+- required_engine_version: 26
 
 - macro: open_write
   condition: (evt.type in (open,openat,openat2) and evt.is_open_write=true and fd.typechar='f' and fd.num>=0)

--- a/rules/falco-sandbox_rules.yaml
+++ b/rules/falco-sandbox_rules.yaml
@@ -25,7 +25,7 @@
 
 # Starting with version 8, the Falco engine supports exceptions.
 # However the Falco rules file does not use them by default.
-- required_engine_version: 0.26.0
+- required_engine_version: 26
 
 # Currently disabled as read/write are ignored syscalls. The nearly
 # similar open_write/open_read check for files being opened for

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -25,7 +25,7 @@
 
 # Starting with version 8, the Falco engine supports exceptions.
 # However the Falco rules file does not use them by default.
-- required_engine_version: 0.26.0
+- required_engine_version: 26
 
 # Currently disabled as read/write are ignored syscalls. The nearly
 # similar open_write/open_read check for files being opened for


### PR DESCRIPTION
The parser in version 0.36.2 reject the 0.26.0 value and `falco --version` report engine_version as 26, so using this number as the value.

/kind bug
/area rules
/area maturity-incubating
/area maturity-sandbox
/area maturity-deprecated