### PR TITLE
update(deprecated_rules): use SemVer `required_engine_version`

### DIFF
--- a/rules/falco-deprecated_rules.yaml
+++ b/rules/falco-deprecated_rules.yaml
@@ -25,7 +25,7 @@
 
 # Starting with version 8, the Falco engine supports exceptions.
 # However the Falco rules file does not use them by default.
-- required_engine_version: 17
+- required_engine_version: 0.17.0
 
 # This macro `never_true` is used as placeholder for tuning negative logical sub-expressions, for example
 # - macro: allowed_ssh_hosts


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area rules


**Proposed rule [maturity level](https://github.com/falcosecurity/rules/blob/main/CONTRIBUTING.md#maturity-levels)**

/area maturity-deprecated

**What this PR does / why we need it**:

This PR adapts the deprecated rule file to use a SemVer-compatible `required_engine_version`. This change would avoid a deprecation warning in Falco 0.37.0 (see https://github.com/falcosecurity/falco/pull/2992)

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
