### PR TITLE
update(sandbox): Added systemd to list of programs ignored when using BPF.

### DIFF
--- a/rules/falco-sandbox_rules.yaml
+++ b/rules/falco-sandbox_rules.yaml
@@ -1699,7 +1699,7 @@
   tags: [maturity_sandbox, container, filesystem, mitre_initial_access, T1611]
 
 - list: bpf_profiled_binaries
-  items: [falco, bpftool]
+  items: [falco, bpftool, systemd]
 
 - macro: bpf_profiled_procs
   condition: (proc.name in (bpf_profiled_binaries))


### PR DESCRIPTION
On Fedora 39, events like this is logged:

  Notice BPF Program  Not Profiled (bpf_cmd=5 evt_type=bpf user=root
  user_uid=0 user_loginuid=-1 process=systemd proc_exepath=/usr/lib/systemd/systemd
  parent=<NA> command=systemd --switched-root --system --deserialize=36 rhgb terminal=0
  exe_flags=<NA> container_id=host container_name=host)

This is just normal systemd behaviour, and not really interesting to log.  The provided patch include systemd in the list of processes allowed to use BPF without any event logged.

/kind bug
/area rules
/area maturity-sandbox