### PR TITLE
fix: change CVE-2024-3094 to match liblzma contain instead of endswith

### DIFF
--- a/rules/falco-incubating_rules.yaml
+++ b/rules/falco-incubating_rules.yaml
@@ -1280,7 +1280,7 @@
   condition: > 
     open_read and 
     proc.name=sshd and 
-    (fd.name endswith "liblzma.so.5.6.0" or fd.name endswith "liblzma.so.5.6.1")
+    (fd.name contains "liblzma.so.5.6.0" or fd.name contains "liblzma.so.5.6.1")
   output: SSHD loaded a backdoored version of liblzma library %fd.name with parent %proc.pname and cmdline %proc.cmdline (process=%proc.name parent=%proc.pname file=%fd.name evt_type=%evt.type user=%user.name user_uid=%user.uid user_loginuid=%user.loginuid proc_exepath=%proc.exepath command=%proc.cmdline terminal=%proc.tty exe_flags=%evt.arg.flags %container.info)
   priority: WARNING
   tags: [maturity_incubating, host, container]


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/area rules
/area maturity-incubating

**What this PR does / why we need it**:

Some of the docs in the wild of how to reproduce XZ vulnerability relies on patching `liblzma` and having the filename with `patch` suffix, for example - `liblzma.so.5.6.1.patch`, thus this Falco rule doesn't pick this up. Changing rule to match `contains` string resolves the issue.

Some examples of who's using `liblzma.so.5.6.1.patch` name:
- https://github.com/amlweems/xzbot/tree/main/assets
- https://github.com/r0binak/xzk8s/blob/main/Dockerfile#L11
