### PR TITLE
fix(.github/workflow): strict naming convention for changed rules files

### DIFF
--- a/.github/workflows/rules.yaml
+++ b/.github/workflows/rules.yaml
@@ -31,15 +31,17 @@ jobs:
       - name: Find changed rules files
         id: set-changed-files
         run: |
-          # if we skip changed-files because we're not in a pull-request,
-          # then we consider all the rules contained in the repo
+          # Find any changed file located under the /rules folder that matches the naming convention <ruleset>_rules.yaml.
+          # See https://github.com/falcosecurity/rules/blob/main/README.md#naming-convention for details.
+          # Additionally, if we skip changed-files because we're not in a pull request,
+          # then we consider all the rules contained in the repository.
           all_files="${{ steps.changed-files.outputs.all }}"
           values=""
           if [ -z "$all_files" ]; then
-            values=$(ls rules/*.yaml)
+            values=$(ls rules/*_rules.yaml)
           else
             for changed_file in $all_files; do
-              if [[ "${changed_file}" =~ ^rules/.* ]]; then
+              if [[ "${changed_file}" =~ ^rules/[^/]*_rules\.yaml$ ]]; then
                 values=${values}${changed_file}$'\n'
               fi
             done


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. This repo contains a dedicated [contributing guide](https://github.com/falcosecurity/rules/blob/main/CONTRIBUTING.md) that highlights the rules maturity framework definitions as well as the criteria for rules acceptance. Please read it carefully before submitting your PR.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR adds or changes one or more rules, please ensure they conform to https://falco.org/docs/rules/style-guide/ and select the appropriate maturity levels.
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome rule"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind feature

/kind bug

> /kind cleanup

> /kind design

/kind documentation

> /kind failing-test


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area rules

> /area registry

/area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Proposed rule [maturity level](https://github.com/falcosecurity/rules/blob/main/CONTRIBUTING.md#maturity-levels)**

> Uncomment one (or more) `/area <>` lines (only for PRs that add or modify rules):

> /area maturity-stable

> /area maturity-incubating

> /area maturity-sandbox

> /area maturity-deprecated

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR aims to address the CI problem discovered in [this PR](https://github.com/falcosecurity/rules/pull/247#issuecomment-2120706869).

The "Validate rules file" job wrongly assumed all files under `/rules` :point_down. However, we have to deal with the possibility that other legitimate files may be stored under that folder.

```
2024-05-20T14:20:44+0000: Falco version: 0.38.0-275+dfbd181 (x86_64)
2024-05-20T14:20:44+0000: CLI args: /usr/bin/falco -o json_output=true -V rules/OWNERS -o log_level=debug -o log_stderr=true -o log_syslog=false -o stdout_output.enabled=true
2024-05-20T14:20:44+0000: Falco initialized with configuration files:
2024-05-20T14:20:44+0000:    /etc/falco/falco.yaml
2024-05-20T14:20:44+0000: System info: Linux version 6.5.0-1021-azure (buildd@lcy02-amd[64](https://github.com/falcosecurity/rules/actions/runs/9160120617/job/25182147619?pr=247#step:6:65)-097) (x86_64-linux-gnu-gcc-11 (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, GNU ld (GNU Binutils for Ubuntu) 2.38) #22~22.04.1-Ubuntu SMP Tue Apr 30 16:08:18 UTC 2024
2024-05-20T14:20:44+0000: Validating rules file(s):
2024-05-20T14:20:44+0000:    rules/OWNERS
2024-05-20T14:20:44+0000: closing inspectors
Error: rules/OWNERS: Invalid
1 Errors:
In rules content: (rules/OWNERS:0:0)
------
approvers:
^
------
LOAD_ERR_YAML_VALIDATE (Error validating internal structure of YAML file): Rules content is not yaml array of objects
```



**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
