### PR TITLE
fix(incubating_rules): revert #508

### DIFF
--- a/rules/falco-incubating_rules.yaml
+++ b/rules/falco-incubating_rules.yaml
@@ -1300,7 +1300,7 @@
     whether the syscall failed or succeeded, remove the direction filter and add the evt.arg.res_or_fd output field.
   condition: >
     evt.type=bpf and evt.dir=> 
-    and evt.arg.cmd=BPF_PROG_LOAD
+    and (evt.arg.cmd=5 or evt.arg.cmd=BPF_PROG_LOAD)
     and not bpf_profiled_procs
   output: BPF Program Not Profiled (bpf_cmd=%evt.arg.cmd evt_type=%evt.type user=%user.name user_uid=%user.uid user_loginuid=%user.loginuid process=%proc.name proc_exepath=%proc.exepath parent=%proc.pname command=%proc.cmdline terminal=%proc.tty %container.info)
   priority: NOTICE

--- a/rules/falco-incubating_rules.yaml
+++ b/rules/falco-incubating_rules.yaml
@@ -1296,7 +1296,7 @@
     BPF is a kernel technology that can be misused for malicious purposes, like "Linux Kernel Module Injection". This 
     rule should be considered an auditing rule to notify you of any unprofiled BPF tools running in your environment. 
     However, it requires customization after profiling your environment. BPF-powered agents make bpf syscalls all the 
-    time, so this rule only sends logs for BPF_PROG_LOAD calls (bpf cmd=BPF_PROG_LOAD) in the enter event. If you also want to log 
+    time, so this rule only sends logs for BPF_PROG_LOAD calls (bpf cmd=5) in the enter event. If you also want to log 
     whether the syscall failed or succeeded, remove the direction filter and add the evt.arg.res_or_fd output field.
   condition: >
     evt.type=bpf and evt.dir=> 


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area rules

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Proposed rule [maturity level](https://github.com/falcosecurity/rules/blob/main/CONTRIBUTING.md#maturity-levels)**

> Uncomment one (or more) `/area <>` lines (only for PRs that add or modify rules):

/area maturity-incubating

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

In https://github.com/falcosecurity/rules/pull/208 we changed the type of the `cmd` argument to a flag type because of changes in https://github.com/falcosecurity/libs/pull/1545 , however the libs PR was only modifying the exit event, while this rule refers to the enter event which is still an INT64, thus we still need to use the value `5` for this event. I noticed this during a conversation with @incertum . 

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
