### PR TITLE
Update(sandbox): Add Netcat/Socat Remote Code Execution on Host rule

### DIFF
--- a/rules/falco-sandbox_rules.yaml
+++ b/rules/falco-sandbox_rules.yaml
@@ -1751,3 +1751,22 @@
   output: Basic Interactive Reconnaissance (evt_type=%evt.type user=%user.name user_uid=%user.uid user_loginuid=%user.loginuid process=%proc.name proc_exepath=%proc.exepath parent=%proc.pname command=%proc.cmdline terminal=%proc.tty exe_flags=%evt.arg.flags %container.info)
   priority: NOTICE
   tags: [maturity_sandbox, host, container, process, mitre_reconnaissance, TA0043]
+
+- rule: Netcat/Socat Remote Code Execution on Host
+  desc: > 
+    Netcat/Socat Program runs on host that allows remote code execution and may be utilized 
+    as a part of a variety of reverse shell payload https://github.com/swisskyrepo/PayloadsAllTheThings/.
+    These programs are of higher relevance as they are commonly installed on UNIX-like operating systems.
+  condition: >
+          spawned_process
+          and not container
+          and ((proc.name = "nc" and (proc.cmdline contains "-e" or
+                                      proc.cmdline contains "-c")) or
+               (proc.name = "ncat" and (proc.args contains "--sh-exec" or
+                                        proc.args contains "--exec" or proc.args contains "-e " or
+                                        proc.args contains "-c " or proc.args contains "--lua-exec")) or
+               (proc.name = 'socat' and (proc.args contains "EXEC" or
+                                         proc.args contains "SYSTEM")))
+  output: Netcat/Socat runs on host that allows remote code execution (evt_type=%evt.type user=%user.name user_uid=%user.uid user_loginuid=%user.loginuid process=%proc.name proc_exepath=%proc.exepath parent=%proc.pname command=%proc.cmdline terminal=%proc.tty exe_flags=%evt.arg.flags)
+  priority: WARNING
+  tags: [maturity_sandbox, host, network, process, mitre_execution, T1059]


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind feature

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area rules

> /area registry

> /area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Proposed rule [maturity level](https://github.com/falcosecurity/rules/blob/main/CONTRIBUTING.md#maturity-levels)**

> Uncomment one (or more) `/area <>` lines (only for PRs that add or modify rules):

> /area maturity-stable

> /area maturity-incubating

/area maturity-sandbox

> /area maturity-deprecated

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Noticed there was no `host` equivalent for the `Netcat Remote Code Execution in Container` rule, so created this rule.
Added socat to the commands to be detected aswell.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests`, please post the related issues/tests in a comment and do not use `Fixes`.
-->


**Special notes for your reviewer**:
