### PR TITLE
rules: add runc to known_memfd_execution_binaries

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -1230,10 +1230,15 @@
   tags: [maturity_stable, host, container, network, process, mitre_execution, T1059]
 
 - list: known_memfd_execution_binaries
-  items: []
+  items: [runc]
 
 - macro: known_memfd_execution_processes
-  condition: (proc.name in (known_memfd_execution_binaries))
+  condition: > 
+    (proc.name in (known_memfd_execution_binaries))
+    or (proc.pname in (known_memfd_execution_binaries))
+    or (proc.exepath = "memfd:runc_cloned:/proc/self/exe")
+    or (proc.exe = "memfd:runc_cloned:/proc/self/exe")
+
 
 - rule: Fileless execution via memfd_create
   desc: >


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. This repo contains a dedicated [contributing guide](https://github.com/falcosecurity/rules/blob/main/CONTRIBUTING.md) that highlights the rules maturity framework definitions as well as the criteria for rules acceptance. Please read it carefully before submitting your PR.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR adds or changes one or more rules, please ensure they conform to https://falco.org/docs/rules/style-guide/ and select the appropriate maturity levels.
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome rule"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind feature

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area rules

> /area registry

> /area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Proposed rule [maturity level](https://github.com/falcosecurity/rules/blob/main/CONTRIBUTING.md#maturity-levels)**

> Uncomment one (or more) `/area <>` lines (only for PRs that add or modify rules):

> /area maturity-stable

> /area maturity-incubating

/area maturity-sandbox

> /area maturity-deprecated

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
This PR is to extend the `known_memfd_execution_binaries` with runc since in 1.1.15 of runc, it introduced a behavior which would use the memfd approach to execute runc binary. This PR is to include the rule for it so that we don't falsely flag the runc binary.

**Which issue(s) this PR fixes**: 

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #3444

**Special notes for your reviewer**:
I can use come help confirming the change. I was able to verify the override works, see the [proof](https://github.com/falcosecurity/falco/issues/3444#issuecomment-2589906819).

But I would need help on verifying that via the first party rules for falco.