### PR TITLE
rules: add support for k3s to containerd_activities macro

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -919,7 +919,9 @@
 
 - macro: containerd_activities
   condition: (proc.name=containerd and (fd.name startswith "/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/" or
-                                        fd.name startswith "/var/lib/containerd/tmpmounts/"))
+                                        fd.name startswith "/var/lib/rancher/k3s/agent/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots" or
+                                        fd.name startswith "/var/lib/containerd/tmpmounts/" or
+                                        fd.name startswith "/var/lib/rancher/k3s/agent/containerd/tmpmounts/"))
 
 - rule: Clear Log Activities
   desc: > 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. This repo contains a dedicated [contributing guide](https://github.com/falcosecurity/rules/blob/main/CONTRIBUTING.md) that highlights the rules maturity framework definitions as well as the criteria for rules acceptance. Please read it carefully before submitting your PR.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR adds or changes one or more rules, please ensure they conform to https://falco.org/docs/rules/style-guide/ and select the appropriate maturity levels.
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome rule"
-->

**What type of PR is this?**

/kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area rules

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Proposed rule [maturity level](https://github.com/falcosecurity/rules/blob/main/CONTRIBUTING.md#maturity-levels)**

/area maturity-stable

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

K3s is a stripped down version of Kubernetes that bundles dependencies within it, including containerd. It puts containerd files (sockets, tmpmounts, snapshotter overlayfs, etc.) in namespaced, non-standard locations in an attempt to not interfere with a system-wide containerd installation. As a result, the "Clear Log Activities" rule triggers warnings for the bundled containerd. Fix that by including K3s' non-standard paths in the containerd_activities macro.