### PR TITLE
fix(rules): fixed `container_started` macro adapting to new container plugin

### DIFF
--- a/rules/falco-incubating_rules.yaml
+++ b/rules/falco-incubating_rules.yaml
@@ -296,9 +296,7 @@
 
 - macro: container_started
   condition: >
-    ((evt.type = container or
-     (spawned_process and proc.vpid=1)) and
-     container.image.repository != incomplete)
+     (spawned_process and proc.vpid=1 and container)
 
 - list: cron_binaries
   items: [anacron, cron, crond, crontab]
@@ -610,7 +608,6 @@
     seen as more suspicious, prompting a closer inspection.
   condition: >
     container_started 
-    and container
     and container.privileged=true
     and not falco_privileged_containers
     and not user_privileged_containers
@@ -640,7 +637,6 @@
     raise suspicion, prompting closer scrutiny.
   condition: >
     container_started 
-    and container
     and excessively_capable_container
     and not falco_privileged_containers
     and not user_privileged_containers

--- a/rules/falco-sandbox_rules.yaml
+++ b/rules/falco-sandbox_rules.yaml
@@ -327,9 +327,7 @@
 
 - macro: container_started
   condition: >
-    ((evt.type = container or
-     (spawned_process and proc.vpid=1)) and
-     container.image.repository != incomplete)
+    (spawned_process and proc.vpid=1 and container)
 
 # Possible scripts run by sshkit
 - list: sshkit_script_binaries
@@ -1265,7 +1263,6 @@
     varies based on your environment.
   condition: >
     container_started 
-    and container
     and sensitive_mount
     and not falco_sensitive_mount_containers
     and not user_sensitive_mount_containers
@@ -1292,7 +1289,6 @@
     this can be challenging to manage.
   condition: > 
     container_started 
-    and container 
     and not allowed_containers
   output: Container started and not in allowed list | evt_type=%evt.type user_uid=%user.uid user_loginuid=%user.loginuid process=%proc.name proc_exepath=%proc.exepath parent=%proc.pname command=%proc.cmdline terminal=%proc.tty
   priority: WARNING


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area rules

**Proposed rule [maturity level](https://github.com/falcosecurity/rules/blob/main/CONTRIBUTING.md#maturity-levels)**

/area maturity-incubating
/area maturity-sandbox

**What this PR does / why we need it**:

In `container_started` macro, avoid using the meta, internal `container` event to check for spawned containers, since the new container plugin will send that event **before** the first process inside the container has spawned.
Instead, just rely on `vpid==1` and `container.id!=host`.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

See https://github.com/falcosecurity/falco/issues/3610

Fixes #

**Special notes for your reviewer**:
