### PR TITLE
Add Rule: Detect Core Pattern Pipe Abuse for Container Escape (T1611)

### DIFF
--- a/rules/core_pattern_escape_attempt.yml
+++ b/rules/core_pattern_escape_attempt.yml
@@ -11,5 +11,5 @@
   output: >
     Core pattern modification to pipe detected | file=%fd.name user=%user.name user_uid=%user.uid user_loginuid=%user.loginuid process=%proc.name proc_exepath=%proc.exepath parent=%proc.pname command=%proc.cmdline terminal=%proc.tty evt_type=%evt.type
   priority: CRITICAL
-  tags: [process, container, escape, mitre_escape, T1611]
+  tags: [maturity_incubating, process, container, escape, mitre_escape, T1611]
   source: syscall


### PR DESCRIPTION
This PR adds a new detection rule for identifying attempts to abuse `/proc/sys/kernel/core_pattern` by redirecting core dumps to a pipe. This technique is often used to escalate privileges or escape containers when the sysctl setting is writable and misconfigured.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. This repo contains a dedicated [contributing guide](https://github.com/falcosecurity/rules/blob/main/CONTRIBUTING.md) that highlights the rules maturity framework definitions as well as the criteria for rules acceptance. Please read it carefully before submitting your PR.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR adds or changes one or more rules, please ensure they conform to https://falco.org/docs/rules/style-guide/ and select the appropriate maturity levels.
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome rule"
-->

**What type of PR is this?**

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> /area rules

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Proposed rule [maturity level](https://github.com/falcosecurity/rules/blob/main/CONTRIBUTING.md#maturity-levels)**

> /area maturity-incubating
<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
Adds a rule that detects write access to `/proc/sys/kernel/core_pattern` containing a pipe symbol (`|`), which may be used to redirect core dumps to arbitrary commands. This has been used in container breakout scenarios and privilege escalations.

### Rule Summary:
- **Rule name:** `Core Pattern Escape Attempt`
- **Detection:** `open_write` on `/proc/sys/kernel/core_pattern` with a pipe (`|`) in the buffer
- **MITRE ATT&CK:** T1611 – Escape to Host
- **Impact:** High – potential root code execution via crash-triggered payloads
**Which issue(s) this PR fixes**:
None currently tracked — original contribution.
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

N/A

**Special notes for your reviewer**:

This rule aligns with documented techniques seen in tools like [CDK](https://github.com/cdk-team/CDK) and various privilege escalation labs. Let me know if you’d like the rule expanded to cover syscall write directly or enriched with container scope conditions.