### PR TITLE
Add macro to support customisation of grep private keys rule

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -877,6 +877,9 @@
        proc.args icontains " user "))
     )
 
+- macro: user_known_search_private_key_or_password_activities
+  condition: (never_true)
+
 - rule: Search Private Keys or Passwords
   desc: >
     Detect attempts to search for private keys or passwords using the grep or find command. This is often seen with 
@@ -892,6 +895,7 @@
                                   proc.args contains "id_ecdsa"
           )
         ))
+    and not user_known_search_private_key_or_password_activities
   output: Grep private keys or passwords activities found | evt_type=%evt.type user=%user.name user_uid=%user.uid user_loginuid=%user.loginuid process=%proc.name proc_exepath=%proc.exepath parent=%proc.pname command=%proc.cmdline terminal=%proc.tty exe_flags=%evt.arg.flags
   priority:
     WARNING


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area rules

**Proposed rule [maturity level](https://github.com/falcosecurity/rules/blob/main/CONTRIBUTING.md#maturity-levels)**

> Uncomment one (or more) `/area <>` lines (only for PRs that add or modify rules):

/area maturity-stable

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

We have a scenario where a container has a valid use case to grep private keys. The "grep private key or password files" rule, unlike most rules, does not support a macro to allow exceptions. This PR addresses that

**Special notes for your reviewer**:
