### PR TITLE
feature(rules): add EKS mount exclusion for privileged container rule

### DIFF
--- a/rules/falco-incubating_rules.yaml
+++ b/rules/falco-incubating_rules.yaml
@@ -1119,6 +1119,11 @@
     ((k8s.ns.name = kube-system and container.image.repository in (mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi,mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi))
     or (k8s.ns.name = system and container.image.repository = mcr.microsoft.com/oss/kubernetes-csi/secrets-store/driver))
 
+- macro: known_eks_mount_in_privileged_containers
+  condition:
+    (k8s.ns.name = kube-system
+    and container.image.repository = public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver)
+
 - macro: user_known_mount_in_privileged_containers
   condition: (never_true)
 
@@ -1135,6 +1140,7 @@
     and not mount_info
     and not known_gke_mount_in_privileged_containers
     and not known_aks_mount_in_privileged_containers
+    and not known_eks_mount_in_privileged_containers
     and not user_known_mount_in_privileged_containers
   output: Mount was executed inside a privileged container | evt_type=%evt.type user=%user.name user_uid=%user.uid user_loginuid=%user.loginuid process=%proc.name proc_exepath=%proc.exepath parent=%proc.pname command=%proc.cmdline terminal=%proc.tty exe_flags=%evt.arg.flags
   priority: WARNING


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. This repo contains a dedicated [contributing guide](https://github.com/falcosecurity/rules/blob/main/CONTRIBUTING.md) that highlights the rules maturity framework definitions as well as the criteria for rules acceptance. Please read it carefully before submitting your PR.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR adds or changes one or more rules, please ensure they conform to https://falco.org/docs/rules/style-guide/ and select the appropriate maturity levels.
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome rule"
-->

**What type of PR is this?**

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area rules

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Proposed rule [maturity level](https://github.com/falcosecurity/rules/blob/main/CONTRIBUTING.md#maturity-levels)**

/area maturity-incubating

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

- Add `known_eks_mount_in_privileged_containers` macro to exclude legitimate EKS EBS CSI driver mount operations
- Update "Mount Launched in Privileged Container" rule to prevent false positives from EKS CSI driver mounts
- Follows existing pattern used for GKE and AKS exclusions

This change reduces false positives in EKS environments where the EBS CSI driver legitimately performs mount operations in privileged containers. Similar exclusions already exist for GKE and AKS environments.