### PR TITLE
Update k8s_containers macro to allow more to contact k8s API server

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -804,6 +804,7 @@
      ibm_cloud_containers,
      docker.io/velero/velero, velero/velero,
      registry.k8s.io/sig-storage/nfs-subdir-external-provisioner,
+     quay.io/metallb/controller, quay.io/metallb/speaker,
      quay.io/jetstack/cert-manager-cainjector, weaveworks/kured,
      quay.io/prometheus-operator/prometheus-operator,
      quay.io/prometheus/prometheus,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. This repo contains a dedicated [contributing guide](https://github.com/falcosecurity/rules/blob/main/CONTRIBUTING.md) that highlights the rules maturity framework definitions as well as the criteria for rules acceptance. Please read it carefully before submitting your PR.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR adds or changes one or more rules, please ensure they conform to https://falco.org/docs/rules/style-guide/ and select the appropriate maturity levels.
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome rule"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind feature

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area rules

> /area registry

> /area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Proposed rule [maturity level](https://github.com/falcosecurity/rules/blob/main/CONTRIBUTING.md#maturity-levels)**

> Uncomment one (or more) `/area <>` lines (only for PRs that add or modify rules):

/area maturity-stable

> /area maturity-incubating

> /area maturity-sandbox

> /area maturity-deprecated

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR enhances the existing stable rule " Contact K8S API Server From Container" with a few adjustments:

- grafana uses k8s-sidecar containers, that call the API server
- snapshot-controller (from sig-storage) needs the API server
- metallb needs the API server
- velero/velero container can also be prefixed with `docker.io/`
- nfs-subdir-external-provisioner (from sig-storage) needs the API server
- prometheus containers use the API server as a target (with default configuration of [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) helm chart)

There's another scenario that can trigger this rule with the kube-prometheus-stack helm chart. Depending on your values.yaml, it can run a job that deploys the CRDs. This job uses a container based on registry.k8s.io/kubectl image with command `kubectl apply --server-side --filename /tmp/crds.yaml`, that triggers this rule. However, I did not find a clean and generic way to implement an exception for it