### PR TITLE
Add rkhunter in the binaries allowed to read sensitive files

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -364,7 +364,7 @@
     vsftpd, systemd, mysql_install_d, psql, screen, debconf-show, sa-update,
     pam-auth-update, pam-config, /usr/sbin/spamd, polkit-agent-he, lsattr, file, sosreport,
     scxcimservera, adclient, rtvscand, cockpit-session, userhelper, ossec-syscheckd,
-    sshd-session
+    sshd-session, rkhunter
     ]
 
 # Add conditions to this macro (probably in a separate file,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. This repo contains a dedicated [contributing guide](https://github.com/falcosecurity/rules/blob/main/CONTRIBUTING.md) that highlights the rules maturity framework definitions as well as the criteria for rules acceptance. Please read it carefully before submitting your PR.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR adds or changes one or more rules, please ensure they conform to https://falco.org/docs/rules/style-guide/ and select the appropriate maturity levels.
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome rule"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind feature

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area rules

> /area registry

> /area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Proposed rule [maturity level](https://github.com/falcosecurity/rules/blob/main/CONTRIBUTING.md#maturity-levels)**

> Uncomment one (or more) `/area <>` lines (only for PRs that add or modify rules):

/area maturity-stable

> /area maturity-incubating

> /area maturity-sandbox

> /area maturity-deprecated

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

https://www.rkhunter.dev/ tool needs to read sensitive files (at least /etc/shadow)

In my custom config, I also restricted it on the host (`container.id=host`), this PR allows it anywhere.