### PR TITLE
fix(sandbox): replace user.uid with user.loginuid in SUID privilege escalation rules

### DIFF
--- a/rules/falco-sandbox_rules.yaml
+++ b/rules/falco-sandbox_rules.yaml
@@ -1622,7 +1622,7 @@
     highly specific and might be bypassed due to potential issues with string matching on command line arguments.
   condition: >
     spawned_process
-    and user.uid != 0
+    and user.loginuid != 0
     and (proc.name=sudoedit or proc.name = sudo)
     and (proc.args contains -s or proc.args contains -i or proc.args contains --login)
     and (proc.args contains "\ " or proc.args endswith \)
@@ -1655,7 +1655,7 @@
     specific in its scope.
   condition:
     spawned_process
-    and user.uid != 0
+    and user.loginuid != 0
     and proc.name=pkexec
     and proc.args = ''
   output: Detect Polkit pkexec Local Privilege Escalation Exploit (CVE-2021-4034) | args=%proc.args evt_type=%evt.type user=%user.name user_uid=%user.uid user_loginuid=%user.loginuid process=%proc.name proc_exepath=%proc.exepath parent=%proc.pname command=%proc.cmdline terminal=%proc.tty exe_flags=%evt.arg.flags


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area rules

**Proposed rule maturity level**

/area maturity-sandbox

**What this PR does / why we need it**:

`sudo` and `pkexec` are SUID root binaries. Falco's `user.uid` field reflects the **effective UID**, which the kernel sets to 0 when any user executes a SUID binary. The condition `user.uid != 0` is therefore permanently false for these binaries.

Fix: replace `user.uid != 0` with `user.loginuid != 0`.

`user.loginuid` is the Linux kernel audit UID (loginuid), set by PAM at session login and preserved through SUID execution. It correctly identifies the actual caller:

| Scenario | user.uid | user.loginuid | Old condition | New condition |
|---|---|---|---|---|
| non-root on host runs sudo/pkexec | 0 (SUID) | > 0 | false — miss | true — fires  |
| root on host runs sudo/pkexec | 0 (SUID) | 0 | false — miss | false — correct  |
| non-root user in container runs sudo/pkexec | 0 (SUID) | -1 (no PAM) | false — miss | true — fires  |

Verified empirically on Ubuntu 22.04 and 24.04 / kernel 6.8.0 / Falco 0.43.0 via debug rule capturing live `user.uid` and `user.loginuid` field values during pkexec and sudo executions.
