### PR TITLE
new(rules): detect security tool impairment in containers (T1562.001)

### DIFF
--- a/rules/falco-incubating_rules.yaml
+++ b/rules/falco-incubating_rules.yaml
@@ -1007,6 +1007,36 @@
 # when more than one event type is involved because some event will populate
 # the filtercheck and others will always return <NA>. It would be better to use
 # a more generic filter like `fs.path.*`
+- macro: user_known_security_tool_disable_activities
+  condition: (never_true)
+
+- rule: Defense Tool Disabled or Modified in Container
+  desc: >
+    Detect attempts to disable or modify security tooling inside a running container,
+    including flushing firewall rules via iptables or stopping security daemons such
+    as falco, auditd, or sysdig. Adversaries impair defenses after achieving initial
+    execution to operate undetected before lateral movement.
+    Maps to MITRE ATT&CK T1562.001 (Impair Defenses: Disable or Modify Tools).
+  condition: >
+    spawned_process and container
+    and (
+      (proc.name in (iptables, ip6tables) and
+       (proc.args contains "-F" or proc.args contains "--flush" or
+        proc.args contains "-X" or proc.args contains "--delete-chain"))
+      or
+      (proc.name = systemctl and proc.args contains "stop" and
+       (proc.args contains "falco" or proc.args contains "auditd" or
+        proc.args contains "sysdig" or proc.args contains "osquery"))
+      or
+      (proc.name = service and proc.args contains "stop" and
+       (proc.args contains "falco" or proc.args contains "auditd"))
+    )
+    and not user_known_security_tool_disable_activities
+  output: Security tool disabled or firewall rules cleared in container | args=%proc.args evt_type=%evt.type user=%user.name user_uid=%user.uid user_loginuid=%user.loginuid process=%proc.name proc_exepath=%proc.exepath parent=%proc.pname command=%proc.cmdline terminal=%proc.tty container_id=%container.id image=%container.image.repository
+  priority:
+    WARNING
+  tags: [maturity_incubating, container, process, network, mitre_defense_evasion, T1562.001]
+
 - rule: Delete or rename shell history
   desc: >
     Detect shell history deletion, frequently used by unsophisticated adversaries to eliminate evidence.

--- a/rules/falco-incubating_rules.yaml
+++ b/rules/falco-incubating_rules.yaml
@@ -1035,7 +1035,7 @@
   output: Security tool disabled or firewall rules cleared in container | evt_type=%evt.type user=%user.name user_uid=%user.uid user_loginuid=%user.loginuid process=%proc.name proc_exepath=%proc.exepath parent=%proc.pname command=%proc.cmdline terminal=%proc.tty exe_flags=%evt.arg.flags
   priority:
     WARNING
-  tags: [maturity_incubating, container, process, network, mitre_defense_evasion, T1562.001]
+  tags: [maturity_incubating, container, process, mitre_defense_evasion, T1562.001]
 
 - rule: Delete or rename shell history
   desc: >

--- a/rules/falco-incubating_rules.yaml
+++ b/rules/falco-incubating_rules.yaml
@@ -1032,7 +1032,7 @@
        (proc.args contains "falco" or proc.args contains "auditd"))
     )
     and not user_known_security_tool_disable_activities
-  output: Security tool disabled or firewall rules cleared in container | args=%proc.args evt_type=%evt.type user=%user.name user_uid=%user.uid user_loginuid=%user.loginuid process=%proc.name proc_exepath=%proc.exepath parent=%proc.pname command=%proc.cmdline terminal=%proc.tty container_id=%container.id image=%container.image.repository
+  output: Security tool disabled or firewall rules cleared in container | evt_type=%evt.type user=%user.name user_uid=%user.uid user_loginuid=%user.loginuid process=%proc.name proc_exepath=%proc.exepath parent=%proc.pname command=%proc.cmdline terminal=%proc.tty exe_flags=%evt.arg.flags
   priority:
     WARNING
   tags: [maturity_incubating, container, process, network, mitre_defense_evasion, T1562.001]


### PR DESCRIPTION
## Summary
Adds a detection rule for MITRE ATT&CK T1562.001 (Impair Defenses: Disable or Modify Tools) scoped to container workloads.

## What this detects
- `iptables`/`ip6tables` flush or delete-chain commands inside a container
- `systemctl stop` targeting security daemons (falco, auditd, sysdig, osquery)
- `service stop` targeting falco or auditd

## Why this matters
T1562 was the most prevalent defense evasion technique in malware campaigns in 2025. After achieving initial execution in a container (T1059), adversaries commonly disable runtime security tooling before lateral movement. No existing rule in stable, incubating, or sandbox tiers covers this technique for container workloads.

## MITRE ATT&CK
https://attack.mitre.org/techniques/T1562/001/

## False positives
Tunable via `user_known_security_tool_disable_activities` macro. Legitimate iptables usage in containers is rare and should be explicitly allowlisted.

## Testing
Rule fires on: `iptables -F`, `systemctl stop falco`, `service stop auditd` executed inside a running container.
