### PR TITLE
new(rules): detect GPU/accelerator cryptojacking and device access (T1496)

### DIFF
--- a/rules/falco-sandbox_rules.yaml
+++ b/rules/falco-sandbox_rules.yaml
@@ -1972,3 +1972,84 @@
   output: Container accessing host filesystem paths | file=%fd.name evt_type=%evt.type user=%user.name user_uid=%user.uid user_loginuid=%user.loginuid process=%proc.name proc_exepath=%proc.exepath parent=%proc.pname command=%proc.cmdline terminal=%proc.tty
   priority: WARNING
   tags: [maturity_sandbox, container, filesystem, mitre_privilege_escalation, T1611]
+
+#############################################################################
+# GPU / accelerator cryptojacking and unauthorized device access
+#
+# The existing cryptominer rules (Stratum protocol, known miner pool ports,
+# known miner process names) are CPU- and network-centric. They miss GPU
+# cryptojacking entirely: an attacker mining on a GPU need not use a renamed
+# known miner binary nor connect to a known pool domain, but it must open a
+# GPU character device to submit work. These rules add a complementary
+# device-access signal scoped to containers, where direct accelerator access
+# from an unexpected workload is anomalous. T1496 (Resource Hijacking).
+#############################################################################
+
+# GPU and accelerator character devices. Opening one of these is required to
+# submit compute work to NVIDIA (CUDA) or AMD (ROCm) hardware.
+#   /dev/nvidiactl, /dev/nvidia-uvm, /dev/nvidia-uvm-tools: NVIDIA control and
+#     Unified Virtual Memory devices.
+#   /dev/nvidia0../dev/nvidiaN: per-GPU NVIDIA devices (matched by prefix).
+#   /dev/kfd: AMD ROCm Kernel Fusion Driver compute device.
+#   /dev/dri/renderD*: DRM render nodes used by ROCm/OpenCL for compute.
+- list: gpu_device_files
+  items: [/dev/nvidiactl, /dev/nvidia-uvm, /dev/nvidia-uvm-tools, /dev/kfd]
+
+- macro: open_gpu_device
+  condition: >
+    (open_read or open_write)
+    and (fd.name in (gpu_device_files) or
+         fd.name startswith /dev/nvidia or
+         fd.name startswith /dev/dri/renderD)
+
+# Userspace tooling that queries or manages NVIDIA/AMD GPUs. Legitimate when run
+# by an ML/HPC workload; suspicious when spawned inside a workload that has no
+# business touching the accelerator (e.g. a web frontend or a sidecar).
+- list: gpu_management_binaries
+  items: [nvidia-smi, nvidia-debugdump, nvidia-persistenced, nvidia-cuda-mps-control, rocm-smi, rocminfo]
+
+# Tuning hook for environments where specific images legitimately use the GPU.
+# Override with the set of container images (or other criteria) that are
+# expected to access accelerators, e.g.:
+#   - macro: user_known_gpu_workloads
+#     condition: (container.image.repository in (my_ml_images))
+- macro: user_known_gpu_workloads
+  condition: (never_true)
+
+# Disabled by default: in clusters with legitimate ML, HPC, or rendering
+# workloads this rule is noisy until user_known_gpu_workloads is tuned to the
+# set of images expected to access the GPU. Enable after tuning.
+- rule: Container Accessing GPU Device
+  desc: >
+    Detects a container process opening an NVIDIA or AMD GPU or accelerator character device.
+    Opening such a device is required to submit compute work to the hardware, making this a
+    high-signal indicator of GPU cryptojacking when it originates from a workload that is not
+    expected to use accelerators. It complements the network- and process-name-centric
+    cryptominer rules, which a GPU miner can evade by using an unknown binary name and an
+    unknown mining pool. Because a miner cannot submit work to a GPU without opening the device,
+    this device open is a reliable behavioral chokepoint for the Resource Hijacking technique.
+  condition: >
+    open_gpu_device
+    and container
+    and not user_known_gpu_workloads
+  enabled: false
+  output: Container accessing GPU device | device=%fd.name image=%container.image.repository evt_type=%evt.type user=%user.name user_uid=%user.uid user_loginuid=%user.loginuid process=%proc.name proc_exepath=%proc.exepath parent=%proc.pname command=%proc.cmdline terminal=%proc.tty
+  priority: CRITICAL
+  tags: [maturity_sandbox, container, filesystem, mitre_impact, T1496]
+
+- rule: GPU Management Tool Run in Container
+  desc: >
+    Detects execution of an NVIDIA or AMD GPU management or query tool, such as nvidia-smi or
+    rocm-smi, inside a container. Attackers commonly run these tools immediately after gaining
+    access to a GPU-equipped node to fingerprint the available accelerators before deploying a
+    miner. Inside a workload container this is rarely legitimate outside of machine learning and
+    HPC images. It is a signature-style detection that pairs with the device-access rule to
+    provide both a behavioral and a signature view of the same accelerator-hijacking technique.
+  condition: >
+    spawned_process
+    and container
+    and proc.name in (gpu_management_binaries)
+    and not user_known_gpu_workloads
+  output: GPU management tool run in container | image=%container.image.repository evt_type=%evt.type user=%user.name user_uid=%user.uid user_loginuid=%user.loginuid process=%proc.name proc_exepath=%proc.exepath parent=%proc.pname command=%proc.cmdline terminal=%proc.tty exe_flags=%evt.arg.flags
+  priority: CRITICAL
+  tags: [maturity_sandbox, container, process, mitre_impact, T1496]

--- a/rules/falco-sandbox_rules.yaml
+++ b/rules/falco-sandbox_rules.yaml
@@ -2005,8 +2005,14 @@
 # Userspace tooling that queries or manages NVIDIA/AMD GPUs. Legitimate when run
 # by an ML/HPC workload; suspicious when spawned inside a workload that has no
 # business touching the accelerator (e.g. a web frontend or a sidecar).
+#
+# Names are the kernel comm form (task->comm is char[16]: 15 chars plus NUL), as
+# matched by proc.name. Do not "correct" these to their full binary names or they
+# will never match: nvidia-debugdum(p), nvidia-persiste(nced),
+# nvidia-cuda-mps(-control). Same convention as nvidia-installe and
+# unicorn_launche in falco_rules.yaml.
 - list: gpu_management_binaries
-  items: [nvidia-smi, nvidia-debugdump, nvidia-persistenced, nvidia-cuda-mps-control, rocm-smi, rocminfo]
+  items: [nvidia-smi, nvidia-debugdum, nvidia-persiste, nvidia-cuda-mps, rocm-smi, rocminfo]
 
 # Tuning hook for environments where specific images legitimately use the GPU.
 # Override with the set of container images (or other criteria) that are
@@ -2033,10 +2039,15 @@
     and container
     and not user_known_gpu_workloads
   enabled: false
-  output: Container accessing GPU device | device=%fd.name image=%container.image.repository evt_type=%evt.type user=%user.name user_uid=%user.uid user_loginuid=%user.loginuid process=%proc.name proc_exepath=%proc.exepath parent=%proc.pname command=%proc.cmdline terminal=%proc.tty
+  output: Container accessing GPU device | device=%fd.name evt_type=%evt.type user=%user.name user_uid=%user.uid user_loginuid=%user.loginuid process=%proc.name proc_exepath=%proc.exepath parent=%proc.pname command=%proc.cmdline terminal=%proc.tty
   priority: CRITICAL
   tags: [maturity_sandbox, container, filesystem, mitre_impact, T1496]
 
+# Disabled by default for the same reason as the rule above: it is gated on the
+# same untuned user_known_gpu_workloads macro, so until an operator declares
+# which images are expected to touch the accelerator this rule cannot tell a
+# routine nvidia-smi in an ML image from an attacker fingerprinting the GPU.
+# Enable after tuning.
 - rule: GPU Management Tool Run in Container
   desc: >
     Detects execution of an NVIDIA or AMD GPU management or query tool, such as nvidia-smi or
@@ -2050,6 +2061,7 @@
     and container
     and proc.name in (gpu_management_binaries)
     and not user_known_gpu_workloads
-  output: GPU management tool run in container | image=%container.image.repository evt_type=%evt.type user=%user.name user_uid=%user.uid user_loginuid=%user.loginuid process=%proc.name proc_exepath=%proc.exepath parent=%proc.pname command=%proc.cmdline terminal=%proc.tty exe_flags=%evt.arg.flags
+  enabled: false
+  output: GPU management tool run in container | evt_type=%evt.type user=%user.name user_uid=%user.uid user_loginuid=%user.loginuid process=%proc.name proc_exepath=%proc.exepath parent=%proc.pname command=%proc.cmdline terminal=%proc.tty exe_flags=%evt.arg.flags
   priority: CRITICAL
   tags: [maturity_sandbox, container, process, mitre_impact, T1496]


### PR DESCRIPTION
/kind feature

/area rules

/area maturity-sandbox

**What type of PR is this?**

> /kind feature

**Any specific area of the project related to this PR?**

> /area rules
> /area maturity-sandbox

**What this PR does / why we need it**

Adds three `maturity_sandbox` artifacts to `rules/falco-sandbox_rules.yaml` that detect GPU/accelerator cryptojacking — a container opening an NVIDIA/AMD compute device, and GPU management tooling (`nvidia-smi`, `rocm-smi`) running inside a container — closing a coverage gap the existing CPU/network-centric cryptominer rules do not address.

**Problem / motivation**

Falco's current cryptominer coverage in `falco-sandbox_rules.yaml` is CPU- and network-centric:

- *Detect crypto miners using the Stratum protocol* matches `proc.cmdline` for `stratum+tcp` / `stratum+ssl`.
- *Detect outbound connections to common miner pool ports* matches known pool domains/ports.
- *Known Cryptominer Process Executed* matches a fixed list of miner binary names (`xmrig`, `ethminer`, ...).

All three are trivially evaded by a GPU miner. An attacker who has compromised a GPU-equipped node (common in ML/AI and rendering fleets, where idle accelerator capacity is a high-value cryptojacking target) can use a renamed or custom miner binary, connect over an encrypted/proxied channel to an unknown pool, and avoid the `stratum` URI scheme entirely.

What the miner **cannot** avoid is opening a GPU character device to submit work to the hardware (`/dev/nvidia*`, `/dev/nvidiactl`, `/dev/nvidia-uvm` for CUDA; `/dev/kfd` and `/dev/dri/renderD*` for AMD ROCm). That device open is the chokepoint this PR instruments. This is **GPU compute**, distinct from the existing *Privileged Container Device Access* rule, which targets raw block/storage devices (`/dev/sd`, `/dev/nvme`, `/dev/mem`) for container escape (T1611) — no overlap with GPU compute devices.

**Change**

- `list: gpu_device_files` — `/dev/nvidiactl`, `/dev/nvidia-uvm`, `/dev/nvidia-uvm-tools`, `/dev/kfd`.
- `macro: open_gpu_device` — an `open_read`/`open_write` on a `gpu_device_files` entry, any `/dev/nvidia*` per-GPU node, or a `/dev/dri/renderD*` DRM render node.
- `list: gpu_management_binaries` — `nvidia-smi`, `nvidia-debugdump`, `nvidia-persistenced`, `nvidia-cuda-mps-control`, `rocm-smi`, `rocminfo`.
- `macro: user_known_gpu_workloads` (defaults to `never_true`) — the documented tuning hook for clusters with legitimate ML/HPC/rendering workloads, overridable by image (e.g. `container.image.repository in (my_ml_images)`).
- `rule: Container Accessing GPU Device` (priority `CRITICAL`, **disabled by default**) — behavioral signal: a container opens a GPU compute device and is not an allowlisted workload. Shipped disabled because it is noisy until `user_known_gpu_workloads` is tuned to the images expected to use the GPU.
- `rule: GPU Management Tool Run in Container` (priority `CRITICAL`) — signature signal: GPU fingerprinting tooling runs in a non-allowlisted container.

Conventions mirror the adjacent rules: first tag is the maturity level (`maturity_sandbox`); `container` scope, killchain phase (`mitre_impact`) and TTP (`T1496`) tags match the sibling stratum and miner-binary rules; both rules use a `never_true`-backed `user_known_*` tuning macro and the established `evt_type / user / process / proc_exepath / parent / command / terminal` output template. The device-open rule deliberately reuses the exact `(open_read or open_write) and container and fd.name startswith /dev/...` pattern already used by the existing *Privileged Container Device Access* rule in this same file.

**Security rationale**

- **MITRE ATT&CK T1496 — Resource Hijacking** (Impact tactic). GPU cryptojacking is the same technique as CPU cryptojacking on a far higher-value target. Tagged identically to the existing T1496 rules.
- **Defense-in-depth against evasion.** Pairs a *behavioral* detection (device open — hard to avoid) with a *signature* detection (management tooling — high precision), consistent with the project's preference for behavioral robustness over command-line string matching.
- **Bounded false-positive surface.** Both rules are container-scoped and gated by a single documented `user_known_gpu_workloads` tuning macro. The behavioral rule ships `enabled: false` per repo precedent for noisy-by-default rules.

**Testing / validation**

- **Engine validation** against the real Falco engine (the authoritative CI path):
  `falco --validate rules/falco-sandbox_rules.yaml` in `falcosecurity/falco:0.44.1` → `Ok`.
- **Runtime firing proof (modern eBPF, capture-on-host).** Ran Falco live with the `modern_ebpf` driver and the rule temporarily enabled, then opened character-device nodes at the matched paths inside a separate container:
  - `Container Accessing GPU Device` fired **CRITICAL** on `cat /dev/nvidia0` and `head -c1 /dev/nvidiactl` from a `busybox` container:
    `Critical Container accessing GPU device | device=/dev/nvidia0 image=busybox evt_type=openat ... process=cat ... container_name=gpu-trigger2`
  - `GPU Management Tool Run in Container` fired **CRITICAL** on executing `nvidia-smi` inside a container:
    `Critical GPU management tool run in container | image=busybox evt_type=execve process=nvidia-smi ...`
  - This also confirms the `open_read`/`open_write` macros (`fd.typechar='f'`, `fd.num>=0`) do match successful **character-device** opens, exactly as the sibling block-device rule relies on.
- Diff is additive only: 1 file, +81 lines.

**Special notes for your reviewer**

Submitted as `maturity_sandbox` per the maturity framework — an experimental detection that pairs a behavioral and a signature signal. Happy to split the two rules, adjust the device/management-binary lists, or change the default-enabled state based on maintainer preference.
