### PR TITLE
update(falco_rules): exclude systemd helpers from Read sensitive file…

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -427,10 +427,23 @@
     and not linux_bench_reading_etc_shadow
     and not user_known_read_sensitive_files_activities
     and not user_read_sensitive_file_containers
+    and not systemd_sensitive_file_readers
   output: Sensitive file opened for reading by non-trusted program | file=%fd.name gparent=%proc.aname[2] ggparent=%proc.aname[3] gggparent=%proc.aname[4] evt_type=%evt.type user=%user.name user_uid=%user.uid user_loginuid=%user.loginuid process=%proc.name proc_exepath=%proc.exepath parent=%proc.pname command=%proc.cmdline terminal=%proc.tty
   priority: WARNING
   tags: [maturity_stable, host, container, filesystem, mitre_credential_access, T1555]
 
+# systemd spawns short-lived helper processes that legitimately read sensitive
+# account/PAM files (e.g. /etc/shadow, /etc/pam.d/*) during normal operation.
+# These helpers report a bare-number or comm-truncated proc.name, so they cannot
+# be matched by name; proc.exepath (kernel-resolved, unspoofable) is used instead,
+# and each entry is anchored to its expected systemd parent to keep it tight.
+#   - systemd-executor: unit (re)exec deserialize handoff (see falcosecurity/falco#3480)
+#   - systemd-userwork: userdb (User/Group Record Lookup) query worker
+# The rule "Read sensitive file untrusted" uses this macro to avoid FPs.
+- macro: systemd_sensitive_file_readers
+  condition: >
+    ((proc.pname=systemd and proc.exepath=/usr/lib/systemd/systemd-executor) or
+     (proc.pname=systemd-userdbd and proc.exepath=/usr/lib/systemd/systemd-userwork))
 - macro: postgres_running_wal_e
   condition: (proc.pname=postgres and (proc.cmdline startswith "sh -c envdir /etc/wal-e.d/env /usr/local/bin/wal-e" or proc.cmdline startswith "sh -c envdir \"/run/etc/wal-e.d/env\" wal-g wal-push"))
 


### PR DESCRIPTION
/kind bug

/area rules

/area maturity-stable

**What this PR does / why we need it**:

The `Read sensitive file untrusted` rule (maturity_stable) fires false positives on modern systemd hosts when systemd's own short-lived helper processes read account/PAM files during normal operation.

The rule already attempts to exclude systemd, but those exclusions match on `proc.name`, which is unusable for these helpers: it is a bare file-descriptor number (e.g. `16`) for `systemd-executor`, and comm-truncated to 15 chars (`systemd-userwor`) for `systemd-userwork`. The existing name-based exclusions therefore never match, and the rule alerts.

This adds a `systemd_sensitive_file_readers` macro that matches on `proc.exepath` instead. `proc.exepath` is kernel-resolved and cannot be influenced by `argv[0]`, and each entry is anchored to its expected systemd parent so the exclusion stays tight rather than blanket-trusting `/usr/lib/systemd/*`. Two helpers are covered:

- `systemd-executor` — unit (re)exec deserialize handoff
- `systemd-userwork` — userdb (User/Group Record Lookup) query worker

Per the repo's versioning guidelines this is a backward-compatible patch change (adding an exception to an existing rule; no `required_engine_version` change).

**Which issue(s) this PR fixes**:

Fixes #291
Related: falcosecurity/falco#3480

**Special notes for your reviewer**:

The `systemd-userwork` variant was reproduced locally on systemd 259 / Falco 0.44.1 and verified by deterministic capture replay: replaying the same `.scap` against the rule produces 2 `Read sensitive file untrusted` alerts before this change and 0 after, while a genuine untrusted read (`cat /etc/shadow`) still fires.

I could not reproduce the `systemd-executor` variant on my systemd version, but it is documented with full field dumps in #291 (thanks to @marwinski, who identified that `proc.name` matching was the blocker) and in falcosecurity/falco#3480.

If you'd prefer to land this incrementally, I'm happy to scope it down to `systemd-userwork` only — the case I reproduced directly — and track `systemd-executor` separately.

**Does this PR introduce a user-facing change?**:

```release-note
update(falco_rules): exclude legitimate systemd helper processes (systemd-executor, systemd-userwork) from false positives in `Read sensitive file untrusted`
```