### PR TITLE
fix(.github): validate fork PR numbers in create-comment workflow

### DIFF
--- a/.github/workflows/create-comment.yaml
+++ b/.github/workflows/create-comment.yaml
@@ -48,15 +48,30 @@ jobs:
 
             // Validate artifact PR number against the workflow_run context
             // to prevent artifact poisoning (cross-issue comment injection).
-            const head_sha = context.payload.workflow_run.head_sha;
-            const {data: associated_prs} = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              commit_sha: head_sha,
-            });
-            const valid_pr_numbers = associated_prs.map(pr => pr.number);
+            //
+            // For same-repo PRs, workflow_run.pull_requests is populated.
+            // For fork PRs, pull_requests is always empty, so we fall back
+            // to searching for PRs by head repo owner and branch name.
+            const run_prs = context.payload.workflow_run.pull_requests;
+            let valid_pr_numbers = run_prs.map(pr => pr.number);
+
+            if (valid_pr_numbers.length === 0) {
+              // Fork PR: search using the head repo owner and branch from the
+              // workflow_run payload (these fields are set by GitHub, not the fork).
+              const head_owner = context.payload.workflow_run.head_repository.owner.login;
+              const head_branch = context.payload.workflow_run.head_branch;
+              const {data: matching_prs} = await github.rest.pulls.list({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'all',
+                head: `${head_owner}:${head_branch}`,
+                per_page: 10,
+              });
+              valid_pr_numbers = matching_prs.map(pr => pr.number);
+            }
+
             if (!valid_pr_numbers.includes(issue_number)) {
-              core.setFailed(`Artifact PR number ${issue_number} does not match any PR for commit ${head_sha}. Aborting to prevent artifact poisoning.`);
+              core.setFailed(`Artifact PR number ${issue_number} does not match any PR for head ${context.payload.workflow_run.head_repository.owner.login}:${context.payload.workflow_run.head_branch}. Aborting to prevent artifact poisoning.`);
               return;
             }
 


### PR DESCRIPTION
Same fix as falcosecurity/plugins#1509, for the identical workflow in this repository. Reported in falcosecurity/plugins#1505, where @leogr noted this repo needs it too.

### Problem

The validation in `create-comment.yaml` calls `listPullRequestsAssociatedWithCommit` against `context.repo`, which in a `workflow_run` event is always the base repository. For a pull request opened from a fork the head commit lives in the contributor's fork, so the base repo lookup returns an empty list, `valid_pr_numbers` is empty, and the check can never pass.

Branches pushed directly to this repository are unaffected, which is why it goes unnoticed.

### Change

Ports the approach already in use in falcosecurity/libs (falcosecurity/libs@0501075).

- For same-repo pull requests, `workflow_run.pull_requests` is populated and is used directly.
- For fork pull requests it is always empty, so fall back to `pulls.list` on `context.repo` filtered by `head: "<head_repository.owner.login>:<head_branch>"`.

Both values come from the `workflow_run` payload and are set by GitHub rather than by the fork.

### Why this preserves the original guarantee

`pulls.list` is called on the base repository, so every candidate number is a pull request of this repository by construction. No additional `base.repo` or `head.sha` filtering is needed.

The resulting block is byte-identical to the libs implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
